### PR TITLE
be consistent with how we locate the favicon tag

### DIFF
--- a/piecon.js
+++ b/piecon.js
@@ -40,7 +40,7 @@
         var links = document.getElementsByTagName('link');
 
         for (var i = 0, l = links.length; i < l; i++) {
-            if ((links[i].getAttribute('rel') || '').match(/\bicon\b/)) {
+            if (links[i].getAttribute('rel') === 'icon' || links[i].getAttribute('rel') == 'shortcut icon') {
                 return links[i];
             }
         }
@@ -53,7 +53,7 @@
         var head = document.getElementsByTagName('head')[0];
 
         for (var i = 0, l = links.length; i < l; i++) {
-            if (typeof(links[i]) !== 'undefined' && links[i].getAttribute('rel') === 'icon') {
+            if (links[i].getAttribute('rel') === 'icon' || links[i].getAttribute('rel') == 'shortcut icon') {
                 head.removeChild(links[i]);
             }
         }


### PR DESCRIPTION
[Favicon#Standardization](http://en.wikipedia.org/wiki/Favicon#Standardization) states that `shortcut icon` is the only other value for `rel` that's allowed (other than `icon`) so rather than just match on `\bicon\b` (which could match a false positive) I think it would be better to match explicitly either `shortcut icon` or `icon`.

This prevents issue #6 from cropping up again in future, as well.
