### PR TITLE
Uncaught TypeError: Cannot call method 'getAttribute' of undefined in Chrome Beta

### DIFF
--- a/piecon.js
+++ b/piecon.js
@@ -40,7 +40,7 @@
         var links = document.getElementsByTagName('link');
 
         for (var i = 0, l = links.length; i < l; i++) {
-            if (links[i].getAttribute('rel') === 'icon' || links[i].getAttribute('rel') === 'shortcut icon') {
+            if (typeof links[i] !== "undefined" && links[i] !== null && (links[i].getAttribute('rel') === 'icon' || links[i].getAttribute('rel') === 'shortcut icon')) {
                 return links[i];
             }
         }

--- a/piecon.js
+++ b/piecon.js
@@ -53,7 +53,7 @@
         var head = document.getElementsByTagName('head')[0];
 
         for (var i = 0, l = links.length; i < l; i++) {
-            if (links[i] != null && (links[i].getAttribute('rel') === 'icon' || links[i].getAttribute('rel') === 'shortcut icon')) {
+            if (links[i] !== null && (links[i].getAttribute('rel') === 'icon' || links[i].getAttribute('rel') === 'shortcut icon')) {
                 head.removeChild(links[i]);
             }
         }

--- a/piecon.js
+++ b/piecon.js
@@ -53,7 +53,7 @@
         var head = document.getElementsByTagName('head')[0];
 
         for (var i = 0, l = links.length; i < l; i++) {
-            if (links[i] !== null && (links[i].getAttribute('rel') === 'icon' || links[i].getAttribute('rel') === 'shortcut icon')) {
+            if (typeof links[i] !== "undefined" && links[i] !== null && (links[i].getAttribute('rel') === 'icon' || links[i].getAttribute('rel') === 'shortcut icon')) {
                 head.removeChild(links[i]);
             }
         }

--- a/piecon.js
+++ b/piecon.js
@@ -53,7 +53,7 @@
         var head = document.getElementsByTagName('head')[0];
 
         for (var i = 0, l = links.length; i < l; i++) {
-            if (links[i].getAttribute('rel') === 'icon' || links[i].getAttribute('rel') === 'shortcut icon') {
+            if (links[i] != null && (links[i].getAttribute('rel') === 'icon' || links[i].getAttribute('rel') === 'shortcut icon')) {
                 head.removeChild(links[i]);
             }
         }


### PR DESCRIPTION
I have this error Chrome 22.0.1229.56 beta:

Uncaught TypeError: Cannot call method 'getAttribute' of undefined

https://img.skitch.com/20120919-cif8cygc1sxcy5stqk3et2dnf.jpg

Of cource, this is maybe bug in Chrome Beta, but simple check fix this problem :)