### PR TITLE
Fixed a bug in removeFaviconTag()

### DIFF
--- a/piecon.js
+++ b/piecon.js
@@ -55,6 +55,7 @@
         for (var i = 0, l = links.length; i < l; i++) {
             if (links[i].getAttribute('rel') === 'icon' || links[i].getAttribute('rel') === 'shortcut icon') {
                 head.removeChild(links[i]);
+                break;
             }
         }
     };


### PR DESCRIPTION
If there's more <link> element after <link rel="icon">, when you delete <link rel="icon"> the array index shifts and it throws array index out of bounds error.
