### PR TITLE
fix removeFaviconTag error if page exist multiple favicon

### DIFF
--- a/piecon.js
+++ b/piecon.js
@@ -51,7 +51,8 @@
     };
 
     var removeFaviconTag = function() {
-        var links = document.getElementsByTagName('link');
+        // Removed link element will not exist in Nodelist
+        var links = Array.prototype.slice.call(document.getElementsByTagName('link'));
         var head = document.getElementsByTagName('head')[0];
 
         for (var i = 0, l = links.length; i < l; i++) {


### PR DESCRIPTION
Removed link element will not exist in Nodelist.

So if one page exist multiple favicon element, if the first link element was removed, the second loop will throw an error said that cannot call getAttribute function from undefined