### PR TITLE
Remove cross domain dependency

### DIFF
--- a/piecon.js
+++ b/piecon.js
@@ -91,48 +91,36 @@
         var canvas = getCanvas();
         var context = canvas.getContext("2d");
         var percentage = percentage || 0;
-        var src = currentFavicon;
 
-        var faviconImage = new Image();
-        faviconImage.onload = function() {
-            if (context) {
-                context.clearRect(0, 0, canvas.width, canvas.height);
+        if (context) {
+            context.clearRect(0, 0, canvas.width, canvas.height);
 
-                // Draw shadow
+            // Draw shadow
+            context.beginPath();
+            context.moveTo(canvas.width / 2, canvas.height / 2);
+            context.arc(canvas.width / 2, canvas.height / 2, Math.min(canvas.width / 2, canvas.height / 2), 0, Math.PI * 2, false);
+            context.fillStyle = options.shadow;
+            context.fill();
+
+            // Draw background
+            context.beginPath();
+            context.moveTo(canvas.width / 2, canvas.height / 2);
+            context.arc(canvas.width / 2, canvas.height / 2, Math.min(canvas.width / 2, canvas.height / 2) - 2, 0, Math.PI * 2, false);
+            context.fillStyle = options.background;
+            context.fill();
+
+            // Draw pie
+            if (percentage > 0) {
                 context.beginPath();
                 context.moveTo(canvas.width / 2, canvas.height / 2);
-                context.arc(canvas.width / 2, canvas.height / 2, Math.min(canvas.width / 2, canvas.height / 2), 0, Math.PI * 2, false);
-                context.fillStyle = options.shadow;
+                context.arc(canvas.width / 2, canvas.height / 2, Math.min(canvas.width / 2, canvas.height / 2) - 2, (-0.5) * Math.PI, (-0.5 + 2 * percentage / 100) * Math.PI, false);
+                context.lineTo(canvas.width / 2, canvas.height / 2);
+                context.fillStyle = options.color;
                 context.fill();
-
-                // Draw background
-                context.beginPath();
-                context.moveTo(canvas.width / 2, canvas.height / 2);
-                context.arc(canvas.width / 2, canvas.height / 2, Math.min(canvas.width / 2, canvas.height / 2) - 2, 0, Math.PI * 2, false);
-                context.fillStyle = options.background;
-                context.fill();
-
-                // Draw pie
-                if (percentage > 0) {
-                    context.beginPath();
-                    context.moveTo(canvas.width / 2, canvas.height / 2);
-                    context.arc(canvas.width / 2, canvas.height / 2, Math.min(canvas.width / 2, canvas.height / 2) - 2, (-0.5) * Math.PI, (-0.5 + 2 * percentage / 100) * Math.PI, false);
-                    context.lineTo(canvas.width / 2, canvas.height / 2);
-                    context.fillStyle = options.color;
-                    context.fill();
-                }
-
-                setFaviconTag(canvas.toDataURL());
             }
-        };
 
-        // allow cross origin resource requests if the image is not a data:uri
-        // as detailed here: https://github.com/mrdoob/three.js/issues/1305
-        if (!src.match(/^data/)) {
-            faviconImage.crossOrigin = 'anonymous';
+            setFaviconTag(canvas.toDataURL());
         }
-
-        faviconImage.src = src;
     };
 
     var updateTitle = function(percentage) {


### PR DESCRIPTION
We just ran into this issue at @vimeo.  We load our favicon off of a cdn.  

The source is http://f.vimeocdn.com/images_v6/favicon_32.ico

We noticed we were getting a bunch of CORS errors because we do not have access control headers set up for this cdn domain.  I was going to add them, but then it occured to me that they shouldn't be needed.

Unless I'm missing something, it looks to me like each time you call to update the favicon to a specific percentage you first create a new Image() with the source of the currentFavicon and wait for it to load.  This is a lot of extra requests that are not necessary to just write a data uri out to the page, but it also means that it won't work if your favicon is hosted on a separate domain.

You can reproduce the issue by setting the source on your example/index.html page to the url I provided.

This pull request removes all the image preloading so it should also cut down on requests and speed things up.
