### PR TITLE
Fix TypeError on setProgress

### DIFF
--- a/piecon.js
+++ b/piecon.js
@@ -54,7 +54,7 @@
         var links = document.getElementsByTagName('link');
         var head = document.getElementsByTagName('head')[0];
 
-        for (var i = 0, l = links.length; i < l; i++) {
+        for (var i = 0; i < links.length; i++) {
             if (links[i].getAttribute('rel') === 'icon' || links[i].getAttribute('rel') === 'shortcut icon') {
                 head.removeChild(links[i]);
             }


### PR DESCRIPTION
When `removeFaviconTag` actually removes a tag an error is thrown:

    TypeError: Cannot read property 'getAttribute' of undefined

This is because the underlying array (NodeList?) is mutated and the
cached `l` var is not.