### PR TITLE
Fix TypeError on setProgress

### DIFF
--- a/piecon.js
+++ b/piecon.js
@@ -51,7 +51,7 @@
     };
 
     var removeFaviconTag = function() {
-        var links = document.getElementsByTagName('link');
+        var links = Array.prototype.slice.call(document.getElementsByTagName('link'), 0);
         var head = document.getElementsByTagName('head')[0];
 
         for (var i = 0, l = links.length; i < l; i++) {


### PR DESCRIPTION
If there are multiple link elements and favicon is not last,
first setProgress would cause "Cannot read property 'getAttribute' of undefined"

links is now Array instead of HTMLCollection, so that it does't change while for
loop iterates through it.

Closes #17
Closes #13
Closes #11
